### PR TITLE
Updated dependency aurelia-binding to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,21 +21,20 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "aurelia-breeze",
     "format": "amd",
     "directories": {
       "dist": "dist/amd"
     },
     "peerDependencies": {
-      "aurelia-binding": "^1.0.0-rc.1.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-fetch-client": "^1.0.0-rc.1.0.0",
       "aurelia-pal": "^1.0.0-rc.1.0.0",
       "aurelia-templating": "^1.0.0-rc.1.0.0",
       "breeze-client": "^1.5.6"
     },
     "dependencies": {
-      "aurelia-binding": "^1.0.0-rc.1.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-fetch-client": "^1.0.0-rc.1.0.0",
       "aurelia-pal": "^1.0.0-rc.1.0.0",
       "aurelia-templating": "^1.0.0-rc.1.0.0",
@@ -53,7 +52,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.0.0-rc.1.0.0",
+    "aurelia-binding": "^2.0.0",
     "aurelia-fetch-client": "^1.0.0-rc.1.0.0",
     "aurelia-pal": "^1.0.0-rc.1.0.0",
     "aurelia-templating": "^1.0.0-rc.1.0.0",


### PR DESCRIPTION
Required for jspm to get version 2
jspm does not support comparitor sets for versioning
See aurelia binding reported issue https://github.com/aurelia/framework/pull/897
See jspm root issue https://github.com/jspm/jspm-cli/issues/2406